### PR TITLE
asObject is "one shot", asObjectType offers more

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -15,6 +15,7 @@
     "globals"  : {
         /* MOCHA */
         "describe"   : false,
+        "context"    : false,
         "it"         : false,
         "before"     : false,
         "beforeEach" : false,

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ matrix:
         - node_js: "iojs"
 
 after_success:
+    - npm run travis-cov
     - npm run coveralls
 
 sudo: false

--- a/README.md
+++ b/README.md
@@ -2,15 +2,37 @@
 [![Coverage Status][cov-img]][cov-url]
 [![Code Climate][clim-img]][clim-url]
 
-## Postfix Parser
+# Postfix Parser
 
 It parses postfix log entries.
 
     var parser = require('postfix-parser');
 
-### asObject
 
-Exports and single function: asObject, which requires two positional arguments:
+# Functions
+
+## asObject
+
+Call with a syslog line:
+
+    parser.asObject('Jul  5 06:52:11 mx1 postfix/qmgr[20459]: 3mPVKl...');
+
+Returns an object:
+
+    {
+        date: 'Jul  5 06:52:11',
+        host: 'prd-mx1',
+        prog: 'postfix/qmgr',
+        pid: '20459',
+        qid: '3mPVKl0Mhjz7sXv',
+        size: '2666',
+        nrcpt: '2',
+    }
+
+
+## asObjectType
+
+requires two positional arguments:
 
 1. type (see Parser Types)
 2. a single line syslog entry (or snippet)

--- a/package.json
+++ b/package.json
@@ -8,18 +8,30 @@
     "maillog",
     "mail.log"
   ],
-  "version": "0.6.0",
+  "version": "0.8.0",
   "private": false,
   "homepage": "https://github.com/DoubleCheck/postfix-parser",
+  "author" : {
+    "name": "Matt Simerson"
+  },
   "repository": {
     "type": "git",
     "url": "git://github.com/DoubleCheck/postfix-parser.git"
   },
   "main": "index.js",
+  "engines": {
+    "node": ">=0.10.0"
+  },
   "config": {
     "blanket": {
       "pattern": "index.js",
-      "data-cover-never": [ "node_modules", "tests" ]
+      "data-cover-never": [
+        "node_modules",
+        "test"
+      ]
+    },
+    "travis-cov": {
+      "threshold": 100
     }
   },
   "dependencies": {},
@@ -27,13 +39,15 @@
     "blanket": "^1.1.7",
     "coveralls": "^2.11.2",
     "mocha": "^2.2.5",
-    "mocha-lcov-reporter": "0.0.2"
+    "mocha-lcov-reporter": "0.0.2",
+    "travis-cov": "^0.2.5"
   },
   "bugs": {
     "url": "https://github.com/DoubleCheck/postfix-parser/issues"
   },
   "scripts": {
     "test": "mocha",
+    "travis-cov": "COVERAGE=1 ./node_modules/.bin/mocha --require blanket --reporter travis-cov",
     "coveralls": "COVERAGE=1 ./node_modules/.bin/mocha --require blanket --reporter mocha-lcov-reporter | ./node_modules/coveralls/bin/coveralls.js"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,57 +1,88 @@
 'use strict';
 /* jshint maxlen: false, camelcase: false, maxstatements: false */
+
 var assert = require('assert');
 var util   = require('util');
 
-var re = require('../index');
+var re     = require('../index');
 
-describe('re.asObject parser', function () {
-
-    it('syslog, spamd line', function () {
-        assert.deepEqual(re.asObject('syslog', 'Jul  5 06:52:01 prd-mx1 spamd[11526]: spamd: identified spam (9.3/5.0) for nagios:1209 in 0.8 seconds, 5 bytes.'),
-            {
-            date: 'Jul  5 06:52:01',
-            host: 'prd-mx1',
-            prog: 'spamd',
-            pid: '11526',
-            msg: 'spamd: identified spam (9.3/5.0) for nagios:1209 in 0.8 seconds, 5 bytes.'
-        });
-    });
-
-    it('syslog postfix/cleanup', function () {
-        assert.deepEqual(re.asObject('syslog', 'Jul  5 06:52:11 prd-mx1 postfix/cleanup[21893]: 3mPVKl0Mhjz7sXv: message-id=<E1ZB06G-0006n5-Vp@anc-dev-web1.slc.example.net>'), {
+var syslogLines = [
+    {
+        name: 'spamd',
+        line: 'Jul  5 06:52:01 prd-mx1 spamd[11526]: spamd: identified spam (9.3/5.0) for nagios:1209 in 0.8 seconds, 5 bytes.',
+        obj: undefined,
+    },
+    {
+        name: 'postfix/cleanup',
+        line: 'Jul  5 06:52:11 prd-mx1 postfix/cleanup[21893]: 3mPVKl0Mhjz7sXv: message-id=<E1ZB06G-0006n5-Vp@anc-dev-web1.slc.example.net>',
+        obj: {
             date: 'Jul  5 06:52:11',
             host: 'prd-mx1',
             prog: 'postfix/cleanup',
             pid: '21893',
-            msg: '3mPVKl0Mhjz7sXv: message-id=<E1ZB06G-0006n5-Vp@anc-dev-web1.slc.example.net>',
-        });
-    });
-
-    it('syslog postfix/qmgr', function () {
-        assert.deepEqual( re.asObject('syslog', 'Jul  5 06:52:11 prd-mx1 postfix/qmgr[20459]: 3mPVKl0Mhjz7sXv: from=<>, size=2666, nrcpt=2 (queue active)'), {
+            qid: '3mPVKl0Mhjz7sXv',
+            'message-id': 'E1ZB06G-0006n5-Vp@anc-dev-web1.slc.example.net',
+        },
+    },
+    {
+        name: 'postfix/qmgr',
+        line: 'Jul  5 06:52:11 prd-mx1 postfix/qmgr[20459]: 3mPVKl0Mhjz7sXv: from=<>, size=2666, nrcpt=2 (queue active)',
+        obj: {
+            qid: '3mPVKl0Mhjz7sXv',
+            size: '2666',
+            nrcpt: '2',
             date: 'Jul  5 06:52:11',
             host: 'prd-mx1',
             prog: 'postfix/qmgr',
-            pid: '20459',
-            msg: '3mPVKl0Mhjz7sXv: from=<>, size=2666, nrcpt=2 (queue active)',
-        });
-    });
-
-    it('syslog postfix/smtp', function () {
-        assert.deepEqual(re.asObject('syslog', 'Jul  5 06:52:11 prd-mx1 postfix/smtp[22030]: 3mPVKl0Mhjz7sXv: to=<56597@continuity.delivery>, relay=10.2.2.85[10.2.2.85]:2527, delay=0.51, delays=0.44/0.01/0.05/0.01, dsn=2.0.0, status=sent (250 2.0.0 Ok: queued as 3mPVKl3YVXz2pS5Z)'), {
+            pid: '20459',            
+        }
+    },
+    {
+        name: 'postfix/smtp',
+        line: 'Jul  5 06:52:11 prd-mx1 postfix/smtp[22030]: 3mPVKl0Mhjz7sXv: to=<56597@continuity.delivery>, relay=10.2.2.85[10.2.2.85]:2527, delay=0.51, delays=0.44/0.01/0.05/0.01, dsn=2.0.0, status=sent (250 2.0.0 Ok: queued as 3mPVKl3YVXz2pS5Z)',
+        obj: {
             date: 'Jul  5 06:52:11',
             host: 'prd-mx1',
             prog: 'postfix/smtp',
             pid: '22030',
-            msg: '3mPVKl0Mhjz7sXv: to=<56597@continuity.delivery>, relay=10.2.2.85[10.2.2.85]:2527, delay=0.51, delays=0.44/0.01/0.05/0.01, dsn=2.0.0, status=sent (250 2.0.0 Ok: queued as 3mPVKl3YVXz2pS5Z)',
+            qid: '3mPVKl0Mhjz7sXv',
+            to:  '56597@continuity.delivery',
+            relay: '10.2.2.85[10.2.2.85]:2527',
+            delay: '0.51',
+            delays: '0.44/0.01/0.05/0.01',
+            dsn: '2.0.0',
+            status: 'sent (250 2.0.0 Ok: queued as 3mPVKl3YVXz2pS5Z)',
+        }
+    },
+    {
+        name: 'empty',
+        line: '',
+        obj: undefined,
+    },
+    {
+        line: 'Jul  5 06:52:11 prd-mx1 postfix/smtp[22030]: 3mPVKl0Mhjz7sXv: to=<56597@con',
+        name: 'truncated',
+        obj: undefined,
+    }
+];
+
+describe('syslog lines', function () {
+    context('asObject', function () {
+        syslogLines.forEach(function (test) {    
+            it(test.name, function () {
+                var res = re.asObject(test.line);
+                assert.deepEqual(res, test.obj, util.inspect(res, {depth: null}));
+            });
         });
     });
+});
 
-    it('postfix/smtp sent', function () {
-        assert.deepEqual(
-            re.asObject('smtp', '3mPVKl0Mhjz7sXv: to=<susan.bck@example.org>, relay=mpafm.example.org[24.100.200.21]:25, conn_use=2, delay=1.2, delays=0.76/0.01/0.09/0.34, dsn=2.0.0, status=sent (250 2.0.0 t5UI2nBt018923-t5UI2nBw018923 Message accepted for delivery)'),
-        {
+var postfixLines = [
+    {
+        line: '3mPVKl0Mhjz7sXv: to=<susan.bck@example.org>, relay=mpafm.example.org[24.100.200.21]:25, conn_use=2, delay=1.2, delays=0.76/0.01/0.09/0.34, dsn=2.0.0, status=sent (250 2.0.0 t5UI2nBt018923-t5UI2nBw018923 Message accepted for delivery)',
+        type: 'postfix/smtp',
+        desc: 'sent',
+        obj: {
             qid: '3mPVKl0Mhjz7sXv',
             to: 'susan.bck@example.org',
             relay: 'mpafm.example.org[24.100.200.21]:25',
@@ -60,13 +91,13 @@ describe('re.asObject parser', function () {
             delays: '0.76/0.01/0.09/0.34',
             dsn: '2.0.0',
             status: 'sent (250 2.0.0 t5UI2nBt018923-t5UI2nBw018923 Message accepted for delivery)',
-        });
-    });
-
-    it('postfix/smtp sent w/o queue ID', function () {
-        assert.deepEqual(
-            re.asObject('smtp', 'to=<susan.bck@example.org>, relay=mpafm.example.org[24.100.200.21]:25, conn_use=2, delay=1.2, delays=0.76/0.01/0.09/0.34, dsn=2.0.0, status=sent (250 2.0.0 t5UI2nBt018923-t5UI2nBw018923 Message accepted for delivery)'),
-        {
+        }
+    },
+    {
+        line: 'to=<susan.bck@example.org>, relay=mpafm.example.org[24.100.200.21]:25, conn_use=2, delay=1.2, delays=0.76/0.01/0.09/0.34, dsn=2.0.0, status=sent (250 2.0.0 t5UI2nBt018923-t5UI2nBw018923 Message accepted for delivery)',
+        type: 'postfix/smtp',
+        desc: 'sent w/o qid',
+        obj: {
             to: 'susan.bck@example.org',
             relay: 'mpafm.example.org[24.100.200.21]:25',
             conn_use: '2',
@@ -74,12 +105,13 @@ describe('re.asObject parser', function () {
             delays: '0.76/0.01/0.09/0.34',
             dsn: '2.0.0',
             status: 'sent (250 2.0.0 t5UI2nBt018923-t5UI2nBw018923 Message accepted for delivery)',
-        });
-    });
-
-    it('postfix/smtp bounced', function () {
-        assert.deepEqual(re.asObject('smtp', '3mPVKl0Mhjz7sXv: to=<jpayne@recipient.com>, relay=mail2.sender.com[66.100.32.07]:25, conn_use=2, delay=2.5, delays=1.6/0.01/0.08/0.81, dsn=5.7.1, status=bounced (host mail2.sender.com[66.100.32.07] said: 550 5.7.1 Unable to deliver to <jpayne@recipient.com> (in reply to RCPT TO command))'),
-        {
+        }
+    },
+    {
+        line: '3mPVKl0Mhjz7sXv: to=<jpayne@recipient.com>, relay=mail2.sender.com[66.100.32.07]:25, conn_use=2, delay=2.5, delays=1.6/0.01/0.08/0.81, dsn=5.7.1, status=bounced (host mail2.sender.com[66.100.32.07] said: 550 5.7.1 Unable to deliver to <jpayne@recipient.com> (in reply to RCPT TO command))',
+        type: 'postfix/smtp',
+        desc: 'bounced',
+        obj: {
             qid: '3mPVKl0Mhjz7sXv',
             to: 'jpayne@recipient.com',
             relay: 'mail2.sender.com[66.100.32.07]:25',
@@ -88,12 +120,13 @@ describe('re.asObject parser', function () {
             delays: '1.6/0.01/0.08/0.81',
             dsn: '5.7.1',
             status: 'bounced (host mail2.sender.com[66.100.32.07] said: 550 5.7.1 Unable to deliver to <jpayne@recipient.com> (in reply to RCPT TO command))',
-        });
-    });
-
-    it('postfix/smtp sent', function () {
-        assert.deepEqual(re.asObject('smtp', '3mPVKl0Mhjz7sXv: to=<rdunn@example.com>, relay=mailout.example.com[199.200.300.131]:25, conn_use=3, delay=2.3, delays=0.55/0/0.08/1.6, dsn=2.6.0, status=sent (250 2.6.0 message received)'),
-        {
+        }
+    },
+    {
+        line: '3mPVKl0Mhjz7sXv: to=<rdunn@example.com>, relay=mailout.example.com[199.200.300.131]:25, conn_use=3, delay=2.3, delays=0.55/0/0.08/1.6, dsn=2.6.0, status=sent (250 2.6.0 message received)',
+        type: 'postfix/smtp',
+        desc: 'sent',
+        obj: {
             qid: '3mPVKl0Mhjz7sXv',
             to: 'rdunn@example.com',
             relay: 'mailout.example.com[199.200.300.131]:25',
@@ -102,12 +135,13 @@ describe('re.asObject parser', function () {
             delays: '0.55/0/0.08/1.6',
             dsn: '2.6.0',
             status: 'sent (250 2.6.0 message received)',
-        });
-    });
-
-    it('postfix/smtp deferred', function () {
-        assert.deepEqual(re.asObject('smtp', '3mPVKl0Mhjz7sXv: to=<health-example-ahslott=foo.com@bar.com>, relay=none, delay=55175, delays=55144/0.05/30/0, dsn=4.4.1, status=deferred (connect to dc-452452f6.bar.com[63.200.300.49]:25: Connection timed out)'),
-        {
+        }
+    },
+    {
+        line: '3mPVKl0Mhjz7sXv: to=<health-example-ahslott=foo.com@bar.com>, relay=none, delay=55175, delays=55144/0.05/30/0, dsn=4.4.1, status=deferred (connect to dc-452452f6.bar.com[63.200.300.49]:25: Connection timed out)',
+        type: 'postfix/smtp',
+        desc: 'deferred',
+        obj: {
             qid: '3mPVKl0Mhjz7sXv',
             to: 'health-example-ahslott=foo.com@bar.com',
             relay: 'none',
@@ -115,12 +149,13 @@ describe('re.asObject parser', function () {
             delays: '55144/0.05/30/0',
             dsn: '4.4.1',
             status: 'deferred (connect to dc-452452f6.bar.com[63.200.300.49]:25: Connection timed out)',
-        });
-    });
+        }
+    },
 
-    it('postfix/smtp sent', function () {
-        assert.deepEqual(re.asObject('smtp', '3mPVKl0Mhjz7sXv: to=<rob@example.com>, relay=mailfilter.example-dom.com[63.200.2.118]:25, conn_use=2, delay=4.4, delays=2/2.2/0.02/0.14, dsn=2.0.0, status=sent (250 ok: Message 7295650 accepted)'),
-        {
+    {
+        line: '3mPVKl0Mhjz7sXv: to=<rob@example.com>, relay=mailfilter.example-dom.com[63.200.2.118]:25, conn_use=2, delay=4.4, delays=2/2.2/0.02/0.14, dsn=2.0.0, status=sent (250 ok: Message 7295650 accepted)',
+        type: 'postfix/smtp',
+        obj: {
             qid: '3mPVKl0Mhjz7sXv',
             to: 'rob@example.com',
             relay: 'mailfilter.example-dom.com[63.200.2.118]:25',
@@ -129,12 +164,13 @@ describe('re.asObject parser', function () {
             delays: '2/2.2/0.02/0.14',
             dsn: '2.0.0',
             status: 'sent (250 ok: Message 7295650 accepted)',
-        });
-    });
-
-    it('postfix/smtp continuity', function () {
-        assert.deepEqual(re.asObject('smtp', '3mPVKl0Mhjz7sXv: to=<56750@continuity.delivery>, relay=10.2.2.85[10.2.2.85]:2527, delay=1.1, delays=1/0.01/0.04/0.05, dsn=2.0.0, status=sent (250 2.0.0 Ok: queued as 3mKPTL0WpJz45Shm)'),
-        {
+        }
+    },
+    {
+        line: '3mPVKl0Mhjz7sXv: to=<56750@continuity.delivery>, relay=10.2.2.85[10.2.2.85]:2527, delay=1.1, delays=1/0.01/0.04/0.05, dsn=2.0.0, status=sent (250 2.0.0 Ok: queued as 3mKPTL0WpJz45Shm)',
+        type: 'postfix/smtp',
+        desc: 'continuity',
+        obj: {
             qid: '3mPVKl0Mhjz7sXv',
             to: '56750@continuity.delivery',
             relay: '10.2.2.85[10.2.2.85]:2527',
@@ -142,68 +178,76 @@ describe('re.asObject parser', function () {
             delays: '1/0.01/0.04/0.05',
             dsn: '2.0.0',
             status: 'sent (250 2.0.0 Ok: queued as 3mKPTL0WpJz45Shm)',
-        });
-    });
-
-    it('postfix/smtp error', function () {
-        assert.deepEqual(re.asObject('smtp', 'connect to mail.mountaineer.k12.mm.us[70.200.138.252]:25: Connection timed out'),
-        {
+        }
+    },
+    {
+        line: 'connect to mail.mountaineer.k12.mm.us[70.200.138.252]:25: Connection timed out',
+        type: 'postfix/smtp',
+        desc: 'error',
+        obj: {
             action: 'delivery',
             mx: 'mail.mountaineer.k12.mm.us[70.200.138.252]:25',
             err: 'Connection timed out',
-        });
-    });
-
-    it('postfix/smtp debug', function () {
-        assert.deepEqual(re.asObject('smtp', '3mhh843cz2zCpsL: enabling PIX workarounds: disable_esmtp delay_dotcrlf for 69.146.200.300[69.146.200.300]:25'),
-        {
+        }
+    },
+    {
+        line: '3mhh843cz2zCpsL: enabling PIX workarounds: disable_esmtp delay_dotcrlf for 69.146.200.300[69.146.200.300]:25',
+        type: 'postfix/smtp',
+        desc: 'debug',
+        obj: {
             debug: ' enabling PIX workarounds'
-        });
-    });
-
-    it('postfix/cleanup message-id', function () {
-        assert.deepEqual(re.asObject('cleanup', '3mKxs35RQsz7sXF: message-id=<3mKxs308vpz7sXd@mx14.example.net>'),
-        {
+        }
+    },
+    {
+        line: '3mKxs35RQsz7sXF: message-id=<3mKxs308vpz7sXd@mx14.example.net>',
+        type: 'postfix/cleanup',
+        desc: 'message-id',
+        obj: {
             qid: '3mKxs35RQsz7sXF',
             'message-id': '3mKxs308vpz7sXd@mx14.example.net',
-        });
-    });
-
-    it('postfix/cleanup message-id w/o queue ID', function () {
-        assert.deepEqual(re.asObject('cleanup', 'message-id=<3mKxs308vpz7sXd@mx14.example.net>'),
-        {
+        }
+    },
+    {
+        line: 'message-id=<3mKxs308vpz7sXd@mx14.example.net>',
+        type: 'postfix/cleanup',
+        desc: 'message-id w/o queue ID',
+        obj: {
             'message-id': '3mKxs308vpz7sXd@mx14.example.net',
-        });
-    });
-
-    it('postfix/cleanup resent-message-id', function () {
-        assert.deepEqual(re.asObject('cleanup', '3mL1Hq0Tgvz7sWh: resent-message-id=<3mL1Hq0Tgvz7sWh@mx14.example.net>'),
-        {
+        }
+    },
+    {
+        line: '3mL1Hq0Tgvz7sWh: resent-message-id=<3mL1Hq0Tgvz7sWh@mx14.example.net>',
+        type: 'postfix/cleanup',
+        desc: 'resent-message-id',
+        obj: {
             qid: '3mL1Hq0Tgvz7sWh',
             'resent-message-id': '3mL1Hq0Tgvz7sWh@mx14.example.net',
-        });
-    });
-
-    it('postfix/pickup', function () {
-        assert.deepEqual(re.asObject('pickup', '3mKxs308vpz7sXd: uid=1206 from=<system>'),
-        {
+        }
+    },
+    {
+        line: '3mKxs308vpz7sXd: uid=1206 from=<system>',
+        type: 'postfix/pickup',
+        desc: '',
+        obj: {
             qid: '3mKxs308vpz7sXd',
             'uid': '1206',
             from: 'system',
-        });
-    });
-
-    it('postfix/pickup w/o queue ID', function () {
-        assert.deepEqual(re.asObject('pickup', 'uid=1206 from=<system>'),
-        {
+        }
+    },
+    {
+        line: 'uid=1206 from=<system>',
+        type: 'postfix/pickup',
+        desc: 'w/o queue ID',
+        obj: {
             'uid': '1206',
             from: 'system',
-        });
-    });
-
-    it('postfix/error', function () {
-        assert.deepEqual(re.asObject('error', '3mJddz5fh3z7sdM: to=<rcarey@example.tv>, relay=none, delay=165276, delays=165276/0.09/0/0.09, dsn=4.4.1, status=deferred (delivery temporarily suspended: connect to 24.200.177.247[24.200.177.247]:25: Connection timed out)'),
-        {
+        }
+    },
+    {
+        line: '3mJddz5fh3z7sdM: to=<rcarey@example.tv>, relay=none, delay=165276, delays=165276/0.09/0/0.09, dsn=4.4.1, status=deferred (delivery temporarily suspended: connect to 24.200.177.247[24.200.177.247]:25: Connection timed out)',
+        type: 'postfix/error',
+        desc: '',
+        obj: {
             qid: '3mJddz5fh3z7sdM',
             to: 'rcarey@example.tv',
             relay: 'none',
@@ -211,39 +255,26 @@ describe('re.asObject parser', function () {
             delays: '165276/0.09/0/0.09',
             dsn: '4.4.1',
             status: 'deferred (delivery temporarily suspended: connect to 24.200.177.247[24.200.177.247]:25: Connection timed out)',
-        });
-    });
-
-    it('postfix/error w/o queue ID', function () {
-        assert.deepEqual(re.asObject('error', 'to=<rcarey@example.tv>, relay=none, delay=165276, delays=165276/0.09/0/0.09, dsn=4.4.1, status=deferred (delivery temporarily suspended: connect to 24.200.177.247[24.200.177.247]:25: Connection timed out)'),
-        {
+        }
+    },
+    {
+        line: 'to=<rcarey@example.tv>, relay=none, delay=165276, delays=165276/0.09/0/0.09, dsn=4.4.1, status=deferred (delivery temporarily suspended: connect to 24.200.177.247[24.200.177.247]:25: Connection timed out)',
+        type: 'postfix/error',
+        desc: 'w/o queue ID',
+        obj: {
             to: 'rcarey@example.tv',
             relay: 'none',
             delay: '165276',
             delays: '165276/0.09/0/0.09',
             dsn: '4.4.1',
             status: 'deferred (delivery temporarily suspended: connect to 24.200.177.247[24.200.177.247]:25: Connection timed out)',
-        });
-    });
-
-    it('postfix/error', function () {
-        var result = re.asObject('postfix/error', '3lz2cf24l8z2yfC: to=<root@localhost.example.net>, orig_to=<root@localhost>, relay=none, delay=3146377, delays=3146377/0.17/0/0.01, dsn=4.4.1, status=deferred (delivery temporarily suspended: connect to 127.0.0.2[127.0.0.2]:25: Connection refused)');
-        assert.deepEqual(result, {
-            qid: '3lz2cf24l8z2yfC',
-            to: 'root@localhost.example.net',
-            orig_to: 'root@localhost',
-            relay: 'none',
-            delay: '3146377',
-            delays: '3146377/0.17/0/0.01',
-            dsn: '4.4.1',
-            status: 'deferred (delivery temporarily suspended: connect to 127.0.0.2[127.0.0.2]:25: Connection refused)'
-        },
-        util.inspect(result));
-    });
-
-    it('postfix/local', function () {
-        assert.deepEqual(re.asObject('local', '3mLQKH6hqhz7sWK: to=<logspam@system.alerts>, relay=local, delay=3.1, delays=1.8/0.86/0/0.44, dsn=2.0.0, status=sent (forwarded as 3mLQKK4rDdz7sVS)'),
-        {
+        }
+    },
+    {
+        line: '3mLQKH6hqhz7sWK: to=<logspam@system.alerts>, relay=local, delay=3.1, delays=1.8/0.86/0/0.44, dsn=2.0.0, status=sent (forwarded as 3mLQKK4rDdz7sVS)',
+        type: 'postfix/local',
+        desc: '',
+        obj: {
             qid: '3mLQKH6hqhz7sWK',
             to: 'logspam@system.alerts',
             relay: 'local',
@@ -252,12 +283,13 @@ describe('re.asObject parser', function () {
             dsn: '2.0.0',
             status: 'forwarded',
             forwardedAs: '3mLQKK4rDdz7sVS',
-        });
-    });
-
-    it('postfix/local w/o queue ID', function () {
-        assert.deepEqual(re.asObject('local', 'to=<logspam@system.alerts>, relay=local, delay=3.1, delays=1.8/0.86/0/0.44, dsn=2.0.0, status=sent (forwarded as 3mLQKK4rDdz7sVS)'),
-        {
+        }
+    },
+    {
+        line: 'to=<logspam@system.alerts>, relay=local, delay=3.1, delays=1.8/0.86/0/0.44, dsn=2.0.0, status=sent (forwarded as 3mLQKK4rDdz7sVS)',
+        type: 'postfix/local',
+        desc: 'w/o queue ID',
+        obj: {
             to: 'logspam@system.alerts',
             relay: 'local',
             delay: '3.1',
@@ -265,85 +297,112 @@ describe('re.asObject parser', function () {
             dsn: '2.0.0',
             status: 'forwarded',
             forwardedAs: '3mLQKK4rDdz7sVS',
-        });
-    });
-
-    it('postfix/bounce', function () {
-        assert.deepEqual(re.asObject('bounce', '3mKxY750hmz7scK: sender non-delivery notification: 3mKxYH0vl4z7sWS'),
-        {
+        }
+    },
+    {
+        line: '3mKxY750hmz7scK: sender non-delivery notification: 3mKxYH0vl4z7sWS',
+        type: 'postfix/bounce',
+        desc: '',
+        obj: {
             qid: '3mKxY750hmz7scK',
             dsnQid: '3mKxYH0vl4z7sWS',
-        });
-    });
-
-    it('postfix/bounce w/o queue ID', function () {
-        assert.deepEqual(re.asObject('bounce', 'sender non-delivery notification: 3mKxYH0vl4z7sWS'),
-        {
+        }
+    },
+    {
+        line: 'sender non-delivery notification: 3mKxYH0vl4z7sWS',
+        type: 'postfix/bounce',
+        desc: 'w/o queue ID',
+        obj: {
             dsnQid: '3mKxYH0vl4z7sWS',
-        });
-    });
-
-    it('postfix/qmgr from', function () {
-        assert.deepEqual(re.asObject('qmgr', '3mKnNK1XhXz7sgL: from=<spruit@example.org>, size=11445, nrcpt=1 (queue active)'),
-        {
+        }
+    },
+    {
+        line: '3mKnNK1XhXz7sgL: from=<spruit@example.org>, size=11445, nrcpt=1 (queue active)',
+        type: 'postfix/qmgr',
+        desc: 'from',
+        obj: {
             qid: '3mKnNK1XhXz7sgL',
             from: 'spruit@example.org',
             size: '11445',
             nrcpt: '1',
-        });
-    });
-
-    it('postfix/qmgr from', function () {
-        assert.deepEqual(re.asObject('qmgr', '3mfNtc147Bz1M9pl: from=<e13f0bfb.ged.hd0.23.hjdjln+lugoe=maevolen.com@bnc.mailjet.com>, size=79660, nrcpt=1 (queue active)'),
-        {
+        }
+    },
+    {
+        line: '3mfNtc147Bz1M9pl: from=<e13f0bfb.ged.hd0.23.hjdjln+lugoe=maevolen.com@bnc.mailjet.com>, size=79660, nrcpt=1 (queue active)',
+        type: 'postfix/qmgr',
+        desc: 'from',
+        obj: {
             qid: '3mfNtc147Bz1M9pl',
             from: 'e13f0bfb.ged.hd0.23.hjdjln+lugoe=maevolen.com@bnc.mailjet.com',
             size: '79660',
             nrcpt: '1',
-        });
-    });
-
-    it('postfix/qmgr from w/o queue ID', function () {
-        assert.deepEqual(re.asObject('qmgr', 'from=<spruit@example.org>, size=11445, nrcpt=1 (queue active)'),
-        {
+        }
+    },
+    {
+        line: 'from=<spruit@example.org>, size=11445, nrcpt=1 (queue active)',
+        type: 'postfix/qmgr',
+        desc: 'from w/o queue ID',
+        obj: {
             from: 'spruit@example.org',
             size: '11445',
             nrcpt: '1',
-        });
-    });
-
-    it('postfix/qmgr expired', function () {
-        assert.deepEqual(re.asObject('qmgr', '3l8L6X6lCPz7t2M: from=<deedee@example.com>, status=expired, returned to sender'),
-        {
+        }
+    },
+    {
+        line: '3l8L6X6lCPz7t2M: from=<deedee@example.com>, status=expired, returned to sender',
+        type: 'postfix/qmgr',
+        desc: 'expired',
+        obj: {
             qid: '3l8L6X6lCPz7t2M',
             from: 'deedee@example.com',
             status: 'expired, returned to sender',
-        });
-    });
-
-    it('postfix/qmgr removed', function () {
-        assert.deepEqual(re.asObject('qmgr', '3l8L6X6lCPz7t2M: removed'),
-        {
+        }
+    },
+    {
+        line: '3l8L6X6lCPz7t2M: removed',
+        type: 'postfix/qmgr',
+        desc: 'removed',
+        obj: {
             qid: '3l8L6X6lCPz7t2M',
             action: 'removed',
-        });
-    });
-
-    it('postfix/scache', function () {
-        assert.deepEqual(re.asObject('scache', 'statistics: domain lookup hits=0 miss=3 success=0%'),
-        {
+        }
+    },
+    {
+        line: 'statistics: domain lookup hits=0 miss=3 success=0%',
+        type: 'postfix/scache',
+        desc: '',
+        obj: {
             statistics: 'domain lookup hits=0 miss=3 success=0%',
-        });
-    });
-
-    it('postfix/postscreen', function () {
-        assert.deepEqual(re.asObject('postscreen', 'WHITELISTED [10.2.2.91]:56553'),
-        {
+        }
+    },
+    {
+        line: 'WHITELISTED [10.2.2.91]:56553',
+        type: 'postfix/postscreen',
+        desc: '',
+        obj: {
             postscreen: 'WHITELISTED [10.2.2.91]:56553',
-        });
-    });
+        }
+    },
+    {
+        line: '',
+        type: 'empty',
+        desc: 'empty args, empty result',
+        obj: undefined,
+    },
+    {
+        line: 'Jul  5 06:52:11 prd-mx1 postfix/smtp[22030]: 3mPVKl0Mhjz7sXv: to=<56597@con',
+        type: 'postfix/smtp',
+        desc: 'truncated',
+        obj: undefined,
+    }
+];
 
-    it('empty args, empty result', function () {
-        assert.deepEqual(re.asObject('', ''), undefined);
+describe('postfix lines', function () {
+    describe('asObjectType', function () {
+        postfixLines.forEach(function (test) {
+            it(test.type + (test.desc ? ' ' + test.desc : ''), function () {
+                assert.deepEqual(re.asObjectType(test.type, test.line), test.obj);
+            });
+        });
     });
 });

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,1 @@
+--check-leaks


### PR DESCRIPTION
control.
- add travis-cov, so if coverage drops, tests fail
- add tests for asObject
